### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/eventFactory.js
+++ b/eventFactory.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 module.exports = {
     NewEvent: function(eventType, data, metadata) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var assert = require('assert');
 var eventFactory = require('./eventFactory');
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "debug": "^2.2.0",
     "event-store-client": "^0.0.10",
     "lodash": "^4.15.0",
-    "node-uuid": "^1.4.7",
     "q": "^1.4.1",
-    "request-promise": "^2.0.1"
+    "request-promise": "^2.0.1",
+    "uuid": "^3.0.0"
   }
 }

--- a/tests/http.checkStreamExists.js
+++ b/tests/http.checkStreamExists.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var httpConfig = require('./support/httpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('Http Client - Check Stream Exist', function() {
     it('Should return true when a stream exist', function() {

--- a/tests/http.deleteStream.js
+++ b/tests/http.deleteStream.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var httpConfig = require('./support/httpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('Http Client - Delete stream', function() {
     it('Should return successful on stream delete', function() {

--- a/tests/http.getAllStreamEvents.js
+++ b/tests/http.getAllStreamEvents.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var httpConfig = require('./support/httpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('Http Client - Get All Stream Events', function() {
     it('Should write events and read back all stream events', function() {

--- a/tests/http.getEvents.js
+++ b/tests/http.getEvents.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var httpConfig = require('./support/httpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var _ = require('lodash');
 
 describe('Http Client - Get Events', function() {

--- a/tests/http.projections.js
+++ b/tests/http.projections.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var httpConfig = require('./support/httpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var fs = require('fs');
 var _ = require('lodash');
 

--- a/tests/http.sendScavengeCommand.js
+++ b/tests/http.sendScavengeCommand.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var httpConfig = require('./support/httpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('Http Client - Send Scavenge Command', function() {
     it('Should send scavenge command', function() {

--- a/tests/http.writeEvent.js
+++ b/tests/http.writeEvent.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var httpConfig = require('./support/httpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('Http Client - Write Event', function() {
     it('Write to a new stream and read the event', function() {

--- a/tests/http.writeEvents.js
+++ b/tests/http.writeEvents.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var httpConfig = require('./support/httpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('Http Client - Write Events', function() {
     it('Write to a new stream and read the events', function() {

--- a/tests/tcp.connection.js
+++ b/tests/tcp.connection.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var tcpConfig = require('./support/tcpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('TCP Client - Test Connection', function() {
     it('Should connect and write event on correct connection properties', function() {

--- a/tests/tcp.eventEnumerator.js
+++ b/tests/tcp.eventEnumerator.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var tcpConfig = require('./support/tcpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('TCP Client - Event Enumerator', function() {
     describe('Forward: Reading events', function() {

--- a/tests/tcp.getAllStreamEvents.js
+++ b/tests/tcp.getAllStreamEvents.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var tcpConfig = require('./support/tcpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('TCP Client - Get All Stream Events', function() {
     it('Should write events and read back all stream events', function() {

--- a/tests/tcp.getEvents.js
+++ b/tests/tcp.getEvents.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var tcpConfig = require('./support/tcpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('TCP Client - Get Events', function() {
 

--- a/tests/tcp.subscribeToStream.js
+++ b/tests/tcp.subscribeToStream.js
@@ -2,7 +2,7 @@ var globalHooks = require('./_globalHooks');
 
 var tcpConfig = require('./support/tcpConfig');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var assert = require('assert');
 var q = require('q');
 

--- a/tests/tcp.subscribeToStreamFrom.js
+++ b/tests/tcp.subscribeToStreamFrom.js
@@ -2,7 +2,7 @@ var globalHooks = require('./_globalHooks');
 
 var tcpConfig = require('./support/tcpConfig');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var assert = require('assert');
 var q = require('q');
 

--- a/tests/tcp.writeEvent.js
+++ b/tests/tcp.writeEvent.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var tcpConfig = require('./support/tcpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('TCP Client - Write Event', function() {
     it('Write to a new stream and read the event', function() {

--- a/tests/tcp.writeEvents.js
+++ b/tests/tcp.writeEvents.js
@@ -3,7 +3,7 @@ var globalHooks = require('./_globalHooks');
 var tcpConfig = require('./support/tcpConfig');
 var assert = require('assert');
 var eventstore = require('../index.js');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('TCP Client - Write Events', function() {
     it('Write to a new stream and read the events', function() {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.