### PR TITLE
Fix some errors in the typescript declaration file

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -126,9 +126,10 @@ export class EventEnumeratorResult {
 	events: Event[];
 }
 
+type NewEventFunction = (eventType: string, data: object, metadata: object, eventId: string) => NewEvent;
+
 export class EventFactory {
-	constructor();
-	newEvent(eventType: string, data: object, metadata: object, eventId: string): NewEvent;
+	newEvent: NewEventFunction;
 }
 
 export class HTTPClient {
@@ -181,18 +182,18 @@ export class TCPClient {
 		last(length: number): Promise<EventEnumeratorResult>;
 		previous(length: number): Promise<EventEnumeratorResult>;
 		next(length: number): Promise<EventEnumeratorResult>;
-	}
+	};
 	subscribeToStream(streamName: string, onEventAppeared?: EventAppearedCallback<EventStoreSubscription>, onDropped?: SubscriptionDroppedCallback<EventStoreSubscription>, resolveLinkTos?: boolean): Promise<EventStoreSubscription>;
 	subscribeToStreamFrom(streamName: string, fromEventNumber?: number, onEventAppeared?: EventAppearedCallback<EventStoreCatchUpSubscription>, onLiveProcessingStarted?: LiveProcessingStartedCallback, onDropped?: SubscriptionDroppedCallback<EventStoreCatchUpSubscription>, settings?: SubscribeToStreamFromSettings): Promise<EventStoreCatchUpSubscription>;
 	close(): Promise<void>;
-	getPool(): Promise<TCPPool>;
+	getPool(): Promise<TCPPool<{}>>;
 	closeAllPools(): Promise<void>;
 }
 
 //Deprecated
 export class tcp extends TCPClient {}
 export class http extends HTTPClient {}
-declare function NewEvent(eventType: string, data: object, metadata: object, eventId: string): NewEvent;
+
 export namespace eventFactory {
-	const NewEvent;
+	const NewEvent: NewEventFunction;
 }


### PR DESCRIPTION
Hi! 

First of all, thanks a lot for all the work! I found some errors in the types definition when I update it. 

Here a list. 

    (195, 18) Duplicate identifier 'NewEvent'.
    (16, 14) Duplicate identifier 'NewEvent'.
    (16, 14) Individual declarations in merged declaration 'NewEvent' must be all exported or all local.
    (195, 18) Individual declarations in merged declaration 'NewEvent' must be all exported or all local.
    (131, 80) Cannot find name 'NewEvent'.
    (138, 42) Cannot find name 'NewEvent'.
    (174, 42) Cannot find name 'NewEvent'.
    (195, 96) Cannot find name 'NewEvent'.
    (197, 8) Variable 'NewEvent' implicitly has an 'any' type.
    (188, 21) Generic type 'Pool<T>' requires 1 type argument(s).

I found that there were some problems with the names. I fix them all. You can check too with the command `tsc --noEmit lib/index.d.ts`

I hope I got it right! :)