### PR TITLE
Fix wrong ussage of enums for declarations

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -35,22 +35,11 @@ export class Event {
 	positionCreated?: string;
 }
 
-export enum ProjectionMode {
-  	OneTime = "onetime",
-	Continuous = "continuous"
-}
+export type ProjectionMode = "onetime" | "continuous";
 
-export enum ReadDirection {
-	Forward = "forward",
-	Backward = "backward"
-}
+export type ReadDirection = "forward" | "backward"; 
 
-export enum EmbedType {
-	Body = "body",
-	Rich = "rich",
-	PrettyBody = "PrettyBody",
-	TryHarder = "TryHarder"
-}
+export type EmbedType = "body" | "rich" | "PrettyBody" | "TryHarder";
 
 export class UserCredentials {
 	readonly username: string;


### PR DESCRIPTION
Hi again! 

I found another small bug. With the enums definitions it was forcing me to do this:

```
import {EmbedType} from 'geteventstore-promise';
...
this.client.persistentSubscriptions.getEvents(subscriptionName, streamName, this.messagesToGet, EmbedType.Body)
```

This was giving me the error: Cannot find Body of undefined.

I updated the enums to be types and in that way enforce the user to send once of the allowed values.