### PR TITLE
Typings for 'node-eventstore-client' TCP settings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,10 @@ import {
 	Pool as TCPPool 
 } from "generic-pool";
 
+import {
+	ConnectionSettings
+} from 'geteventstore-promise';
+
 export interface NewEvent {
 	eventId: string;
 	eventType: string;
@@ -57,7 +61,7 @@ export interface HTTPConfig {
 	credentials: UserCredentials;
 }
 
-export interface TCPConfig {
+export interface TCPConfig extends ConnectionSettings {
 	hostname?: string;
 	port?: number;
 	protocol?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,17 +5,14 @@ import {
 	DeleteResult as TCPDeleteResult,
 	EventAppearedCallback,
 	LiveProcessingStartedCallback,
-	SubscriptionDroppedCallback
+	SubscriptionDroppedCallback,
+	ConnectionSettings
 }  from 'node-eventstore-client';
 
 import { 
 	Options as TCPPoolOptions,
 	Pool as TCPPool 
 } from "generic-pool";
-
-import {
-	ConnectionSettings
-} from 'geteventstore-promise';
 
 export interface NewEvent {
 	eventId: string;


### PR DESCRIPTION
Since the TCP interface for this project relies on the awesome [node-eventstore-client](https://github.com/nicdex/node-eventstore-client) project, it makes most sense if `TCPConfig` interface extends `node-eventstore-client`'s `ConnectionSettings` interface for connection configuration.