### PR TITLE
Update metadata/eventId to be optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -153,7 +153,7 @@ export interface EventEnumeratorResult {
 }
 
 export class EventFactory {
-	newEvent: (eventType: string, data: object, metadata: object, eventId: string) => NewEvent;
+	newEvent: (eventType: string, data: object, metadata?: object, eventId?: string) => NewEvent;
 }
 
 export class HTTPClient {


### PR DESCRIPTION
Hello!

Those parameters are optional in the implementation but required in the TypeScript definition. This PR fix the definition on this point.

Thanks,
Sylvain