### PR TITLE
Unify 'onEventAppeared' and 'onEvent' signatures.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,6 @@ import {
 	EventStoreCatchUpSubscription, 
 	WriteResult as TCPWriteResult, 
 	DeleteResult as TCPDeleteResult,
-	EventAppearedCallback,
 	LiveProcessingStartedCallback,
 	SubscriptionDroppedCallback,
 	ConnectionSettings
@@ -13,10 +12,6 @@ import {
 	Options as TCPPoolOptions,
 	Pool as TCPPool 
 } from "generic-pool";
-
-export interface MappedEventAppearedCallback<TSubscription> {
-    (subscription: TSubscription, event: Event): void | Promise<void>;
-}
 
 export interface NewEvent {
 	eventId: string;
@@ -149,6 +144,10 @@ export interface PersistentSubscriptionAssertResult {
 export interface SubscribeToStreamFromSettings {
 	resolveLinkTos?: boolean;
 	readBatchSize?: number;
+}
+
+export interface MappedEventAppearedCallback<TSubscription> {
+    (subscription: TSubscription, event: Event): void | Promise<void>;
 }
 
 export interface EventEnumeratorResult {

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,10 @@ import {
 	Pool as TCPPool 
 } from "generic-pool";
 
+export interface MappedEventAppearedCallback<TSubscription> {
+    (subscription: TSubscription, event: Event): void | Promise<void>;
+}
+
 export interface NewEvent {
 	eventId: string;
 	eventType: string;
@@ -211,8 +215,8 @@ export class TCPClient {
 		previous(count: number): Promise<EventEnumeratorResult>;
 		next(count: number): Promise<EventEnumeratorResult>;
 	};
-	subscribeToStream(streamName: string, onEventAppeared?: EventAppearedCallback<EventStoreSubscription>, onDropped?: SubscriptionDroppedCallback<EventStoreSubscription>, resolveLinkTos?: boolean): Promise<EventStoreSubscription>;
-	subscribeToStreamFrom(streamName: string, fromEventNumber?: number, onEventAppeared?: EventAppearedCallback<EventStoreCatchUpSubscription>, onLiveProcessingStarted?: LiveProcessingStartedCallback, onDropped?: SubscriptionDroppedCallback<EventStoreCatchUpSubscription>, settings?: SubscribeToStreamFromSettings): Promise<EventStoreCatchUpSubscription>;
+	subscribeToStream(streamName: string, onEventAppeared?: MappedEventAppearedCallback<EventStoreSubscription>, onDropped?: SubscriptionDroppedCallback<EventStoreSubscription>, resolveLinkTos?: boolean): Promise<EventStoreSubscription>;
+	subscribeToStreamFrom(streamName: string, fromEventNumber?: number, onEventAppeared?: MappedEventAppearedCallback<EventStoreCatchUpSubscription>, onLiveProcessingStarted?: LiveProcessingStartedCallback, onDropped?: SubscriptionDroppedCallback<EventStoreCatchUpSubscription>, settings?: SubscribeToStreamFromSettings): Promise<EventStoreCatchUpSubscription>;
 	close(): Promise<void>;
 	getPool(): Promise<TCPPool<object>>;
 	closeAllPools(): Promise<void>;

--- a/lib/tcpClient/subscribeToStream.js
+++ b/lib/tcpClient/subscribeToStream.js
@@ -18,7 +18,7 @@ export default (config) => (
 	let connection;
 	const onEvent = (sub, ev) => {
 		const mappedEvent = mapEvents([ev])[0];
-		if (mappedEvent) onEventAppeared(mappedEvent);
+		if (mappedEvent) onEventAppeared(sub, mappedEvent);
 	};
 
 	const onConnected = async () => {

--- a/lib/tcpClient/subscribeToStreamFrom.js
+++ b/lib/tcpClient/subscribeToStreamFrom.js
@@ -23,7 +23,7 @@ export default (config) => (
 		let connection;
 		const onEvent = (sub, ev) => {
 			const mappedEvent = mapEvents([ev])[0];
-			if (mappedEvent) onEventAppeared(mappedEvent);
+			if (mappedEvent) onEventAppeared(sub, mappedEvent);
 		};
 
 		const onConnected = async () => {


### PR DESCRIPTION
`onEvent` has the signature `(subscription, event) => { }`. 
`onEventAppeared` should also be `(subscription, event) => {}` and not `(event) => {}`.

This is as defined in the `EventAppearedCallback` signature, accepted by both the [connection.subscribeToStream(...)](https://github.com/RemoteMetering/geteventstore-promise/blob/818d0f3e31fc0369dbb23e894aa73014e460f402/index.d.ts#L214) and [connection.subscribeToStreamFrom(...)](https://github.com/RemoteMetering/geteventstore-promise/blob/818d0f3e31fc0369dbb23e894aa73014e460f402/index.d.ts#L215) methods in the `get-eventstore-client` library.