### PR TITLE
Fix typo, auth headers and fix dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Set the ES_EXECUTABLE environment variable to point to the eventstore executable
 
 #### Using docker (cluster tests will only run in this mode)
 
-> docker pull eventstore/eventstore
+> docker pull eventstore/eventstore:release-5.0.8
 
 > yarn test:docker
 

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ The stream name
 #### options(optional)
 The mode of the projection to create, defaults to 'continuous'
 
-##### resolveLinktos
+##### resolveLinkTos
 Tells the subscription to resolve link events.
 
 ##### startFrom
@@ -481,8 +481,9 @@ Returns the state of the Projection as a JSON object.
 The name of the projection to get state of.
 
 ##### options(optional)
-    ##### partition
-    The name of the partition to retrieve.
+
+##### partition
+The name of the partition to retrieve.
 
 #### Example
 

--- a/lib/httpClient/persistentSubscriptions/assert.js
+++ b/lib/httpClient/persistentSubscriptions/assert.js
@@ -17,7 +17,7 @@ const createPersistentSubscriptionOptions = (options) => {
 	options = options || {};
 
 	return {
-		resolveLinktos: options.resolveLinktos,
+		resolveLinkTos: options.resolveLinkTos,
 		startFrom: options.startFrom === undefined ? 0 : options.startFrom,
 		extraStatistics: options.extraStatistics,
 		checkPointAfterMilliseconds: options.checkPointAfterMilliseconds,

--- a/lib/httpClient/persistentSubscriptions/getEvents.js
+++ b/lib/httpClient/persistentSubscriptions/getEvents.js
@@ -16,20 +16,34 @@ const createRequest = (config, name, streamName, count, embed) => {
 	return request;
 };
 
-const appendLinkFunctions = (resultObject, links) => {
-	links.forEach(link => resultObject[link.relation] = () => axios.post(link.uri));
+const appendLinkFunctions = (config, resultObject, links) => {
+	links.forEach(
+		(link) =>
+			(resultObject[link.relation] = () =>
+				axios.post(
+					link.uri,
+					{},
+					{
+						auth: {
+							username: config.credentials.username,
+							password: config.credentials.password,
+						},
+					}
+				)
+			)
+  );
 };
 
-const buildResultObject = (response) => {
+const buildResultObject = (config, response) => {
 	const result = { entries: [] };
 
-	appendLinkFunctions(result, response.links);
+	appendLinkFunctions(config, result, response.links);
 
 	result.entries = response.entries.map(entry => {
 		if (entry.data) entry.data = JSON.parse(entry.data);
 
 		const formattedEntry = { event: entry };
-		appendLinkFunctions(formattedEntry, entry.links);
+		appendLinkFunctions(config, formattedEntry, entry.links);
 		return formattedEntry;
 	});
 
@@ -48,5 +62,5 @@ export default (config) => async (name, streamName, count, embed) => {
 	debug('', 'Options: %j', options);
 	const response = await axios(options);
 	debug('', 'Response: %j', response.data);
-	return buildResultObject(response.data);
+	return buildResultObject(config, response.data);
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"axios": "^0.19.2",
 		"debug": "^4.1.1",
 		"generic-pool": "^3.7.1",
-		"node-eventstore-client": "^0.2.15",
+		"node-eventstore-client": "0.2.18",
 		"uuid": "^7.0.1"
 	},
 	"devDependencies": {

--- a/tests/_globalHooks.js
+++ b/tests/_globalHooks.js
@@ -27,7 +27,7 @@ const addContainer = async () => {
 		`${esConfig.options.extHttpPort}:2113`,
 		'-p',
 		`${esConfig.options.extTcpPort}:${esConfig.options.extTcpPort}`,
-		'eventstore/eventstore'
+		'eventstore/eventstore:release-5.0.8'
 	];
 
 	eventstore = spawn('docker', dockerParameters, {

--- a/tests/http.persistentSubscriptions.js
+++ b/tests/http.persistentSubscriptions.js
@@ -91,11 +91,13 @@ describe('HTTP Client - Persistent Subscription', () => {
 
 		const options = {
 			readBatchSize: 121,
+			resolveLinkTos: true
 		};
 		await client.persistentSubscriptions.assert(testSubscriptionName, testStream, options);
 
 		const result = await client.persistentSubscriptions.getSubscriptionInfo(testSubscriptionName, testStream);
 		assert.equal(options.readBatchSize, result.config.readBatchSize);
+		assert.equal(options.resolveLinkTos, result.config.resolveLinktos);
 	});
 
 	it('Should delete persistent subscription', function(done) {

--- a/tests/support/cluster/docker-compose.yml
+++ b/tests/support/cluster/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   eventstore1:
-   image: eventstore/eventstore
+   image: eventstore/eventstore:release-5.0.8
    env_file:
      - common-variables.env
    environment:
@@ -26,7 +26,7 @@ services:
        ipv4_address: 172.16.0.11
        
   eventstore2:
-   image: eventstore/eventstore
+   image: eventstore/eventstore:release-5.0.8
    env_file:
      - common-variables.env
    environment:
@@ -49,7 +49,7 @@ services:
        ipv4_address: 172.16.0.12
    
   eventstore3:
-   image: eventstore/eventstore
+   image: eventstore/eventstore:release-5.0.8
    env_file:
      - common-variables.env
    environment:


### PR DESCRIPTION
# Issues
## Typo
I found a typo for `resolveLinkTos` options for `persistentSubscriptions.assert` method. The parameters is written as `resolveLinkTos` in the `index.d.ts` but `resolveLinktos` is used in the js code. I renamed it to `resolveLinkTos` to align it with HTTP API and other methods of this package (even if eventstore returns a typo in their response). The result of this typo was that the resolve options was always false on the created persistent subscriptions when using typescript.

## LinkFunctions (ackAll, nack...)
When running tests 401 http response was throw because of missing auth headers during linked actions (eg. `ackAll`).

## Dependency
Update dependency to `node-eventstore-client` to version 0.2.18.