### PR TITLE
[Feature] Projections - config + create projection with trackEmittedStreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,11 +443,33 @@ Get all subscriptions info
 # Supported Methods
 
 * start(projectionName)
+    #### projectionName
+    The name of the projection
 * stop(projectionName)
+    #### projectionName
+    The name of the projection
 * reset(projectionName)
+    #### projectionName
+    The name of the projection
 * remove(projectionName)
+    #### projectionName
+    The name of the projection
+* config(projectionName)
+    #### projectionName
+    The name of the projection
 * getState(projectionName, options)
-* getInfo(projectionName)
+    #### projectionName
+    The name of the projection
+
+    #### options
+    Object, `partition` used to specify the partition to query the state with. e.g. `{ partition: 1 }`
+* getInfo(projectionName, includeConfig)
+    #### projectionName
+    The name of the projection
+
+    #### includeConfig
+    Specify if we want to include the projection config in the projection info result set
+
 * enableAll()
 * disableAll()
 * getAllProjectionsInfo()

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ Get all subscriptions info
 * enableAll()
 * disableAll()
 * getAllProjectionsInfo()
-* assert(projectionName, projectionContent, mode, enabled, checkpointsEnabled, emitEnabled)
+* assert(projectionName, projectionContent, mode, enabled, checkpointsEnabled, emitEnabled, trackEmittedStreams)
     #### projectionName
     The name of the projection
 
@@ -470,6 +470,8 @@ Get all subscriptions info
     #### emitEnabled(optional)
     Should enable emitting, defaults to false
 
+    #### trackEmittedStreams(optional)
+    Should track the emitted streams (tracking emitted streams enables you to delete a projection and all the streams that it has created), defaults to false
 
 ## Example for using any projection method
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -179,7 +179,7 @@ export class HTTPClient {
 		start(name: string): Promise<void>;
 		stop(name: string): Promise<void>;
 		reset(name: string): Promise<void>;
-		assert(name: string, projectionContent: string, mode?: ProjectionMode, enabled?: boolean, checkpointsEnabled?: boolean, emitEnabled?: boolean): Promise<void>;
+		assert(name: string, projectionContent: string, mode?: ProjectionMode, enabled?: boolean, checkpointsEnabled?: boolean, emitEnabled?: boolean, trackEmittedStreams?: boolean): Promise<void>;
 		remove(name: string, deleteCheckpointStream?: boolean, deleteStateStream?: boolean): Promise<void>;
 		getState(name: string, options?: ProjectionStateOptions): Promise<object>;
 		getResult(name: string, options?: ProjectionStateOptions): Promise<object>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -181,9 +181,10 @@ export class HTTPClient {
 		reset(name: string): Promise<void>;
 		assert(name: string, projectionContent: string, mode?: ProjectionMode, enabled?: boolean, checkpointsEnabled?: boolean, emitEnabled?: boolean, trackEmittedStreams?: boolean): Promise<void>;
 		remove(name: string, deleteCheckpointStream?: boolean, deleteStateStream?: boolean): Promise<void>;
+		config(name: string): Promise<object>;
 		getState(name: string, options?: ProjectionStateOptions): Promise<object>;
 		getResult(name: string, options?: ProjectionStateOptions): Promise<object>;
-		getInfo(name: string): Promise<object>;
+		getInfo(name: string, includeConfig?: boolean): Promise<object>;
 		getAllProjectionsInfo(): Promise<object>;
 		disableAll(): Promise<void>;
 		enableAll(): Promise<void>;

--- a/lib/httpClient/index.js
+++ b/lib/httpClient/index.js
@@ -16,6 +16,7 @@ import projectionGetInfo from './projections/getInfo';
 import checkStreamExists from './checkStreamExists';
 import projectionAssert from './projections/assert';
 import projectionRemove from './projections/remove';
+import projectionConfig from './projections/config';
 import projectionStart from './projections/start';
 import projectionReset from './projections/reset';
 import projectionStop from './projections/stop';
@@ -48,6 +49,7 @@ export default class HTTPClient {
 		_config.baseUrl = url.format(_config);
 
 		const _getAllProjectionsInfo = projectionGetAllProjectionsInfo(_config);
+		const _getConfig = projectionConfig(_config);
 		const _startProjection = projectionStart(_config);
 		const _stopProjection = projectionStop(_config);
 
@@ -73,7 +75,8 @@ export default class HTTPClient {
 			getAllProjectionsInfo: _getAllProjectionsInfo,
 			getState: projectionGetState(_config),
 			getResult: projectionGetResult(_config),
-			getInfo: projectionGetInfo(_getAllProjectionsInfo),
+			config: projectionConfig(_config),
+			getInfo: projectionGetInfo(_getAllProjectionsInfo, _getConfig),
 			assert: projectionAssert(_config, _getAllProjectionsInfo),
 			disableAll: projectionDisableAll(_getAllProjectionsInfo, _stopProjection),
 			enableAll: projectionEnableAll(_getAllProjectionsInfo, _startProjection)

--- a/lib/httpClient/projections/assert.js
+++ b/lib/httpClient/projections/assert.js
@@ -18,7 +18,8 @@ const buildCreateOptions = (
 	mode,
 	enabled,
 	emitEnabled,
-	checkpointsEnabled
+	checkpointsEnabled,
+	trackEmittedStreams
 ) => {
 	const options = {
 		url: `${config.baseUrl}/projections/${mode}`,
@@ -28,6 +29,7 @@ const buildCreateOptions = (
 			enabled: enabled ? 'yes' : 'no',
 			emit: emitEnabled ? 'yes' : 'no',
 			checkpoints: checkpointsEnabled ? 'yes' : 'no',
+			trackemittedstreams: trackEmittedStreams ? 'yes' : 'no',
 		},
 		data: projectionContent
 	};
@@ -40,7 +42,7 @@ const buildUpdateOptions = (config, name, projectionContent, emitEnabled) => {
 		url: `${config.baseUrl}/projection/${name}/query`,
 		method: 'PUT',
 		params: {
-			emit: emitEnabled ? 'yes' : 'no',
+			emit: emitEnabled ? 'yes' : 'no'
 		},
 		data: projectionContent
 	};
@@ -48,7 +50,7 @@ const buildUpdateOptions = (config, name, projectionContent, emitEnabled) => {
 	return options;
 };
 
-export default (config, getAllProjectionsInfo) => async (name, projectionContent, mode, enabled, checkpointsEnabled, emitEnabled) => {
+export default (config, getAllProjectionsInfo) => async (name, projectionContent, mode, enabled, checkpointsEnabled, emitEnabled, trackEmittedStreams) => {
 	assert(name, `${baseErr}Name not provided`);
 	assert(projectionContent, `${baseErr}Projection Content not provided`);
 
@@ -56,13 +58,14 @@ export default (config, getAllProjectionsInfo) => async (name, projectionContent
 	enabled = enabled || true;
 	checkpointsEnabled = mode === 'continuous' ? true : checkpointsEnabled || false;
 	emitEnabled = emitEnabled || false;
+	trackEmittedStreams = emitEnabled || false;
 
 	const projectionsInfo = await getAllProjectionsInfo();
 	const projectionExists = await doesProjectionExist(projectionsInfo, name);
 	debug('', 'Projection Exists: %j', projectionExists);
 
 	let options = {};
-	if (!projectionExists) options = buildCreateOptions(config, name, projectionContent, mode, enabled, emitEnabled, checkpointsEnabled);
+	if (!projectionExists) options = buildCreateOptions(config, name, projectionContent, mode, enabled, emitEnabled, checkpointsEnabled, trackEmittedStreams);
 	else options = buildUpdateOptions(config, name, projectionContent, emitEnabled);
 
 	debug('', 'Options: %j', options);

--- a/lib/httpClient/projections/config.js
+++ b/lib/httpClient/projections/config.js
@@ -1,0 +1,31 @@
+import assert from 'assert';
+import axios from 'axios';
+import debugModule from 'debug';
+
+const debug = debugModule("geteventstore:getProjectionConfig");
+const baseErr = "Get Projection Config - ";
+
+export default (config) => async (name) => {
+  assert(name, `${baseErr}Name not provided`);
+
+  const response = await axios.get(
+    `${config.baseUrl}/projection/${name}/config`
+  );
+  debug("", "Response: %j", response.data);
+
+  const projectionConfig = {
+    ...response.data,
+    ...{
+      emitEnabled:
+        response.data.emitEnabled === undefined
+          ? false
+          : response.data.emitEnabled,
+      trackEmittedStreams:
+        response.data.trackEmittedStreams === undefined
+          ? false
+          : response.data.trackEmittedStreams,
+    },
+  };
+
+  return projectionConfig;
+};

--- a/lib/httpClient/projections/getInfo.js
+++ b/lib/httpClient/projections/getInfo.js
@@ -1,14 +1,26 @@
-import debugModule from 'debug';
 import assert from 'assert';
+import debugModule from 'debug';
 
-const debug = debugModule('geteventstore:getProjectionInfo');
-const baseErr = 'Get Projection Info - ';
+const debug = debugModule("geteventstore:getProjectionInfo");
+const baseErr = "Get Projection Info - ";
 
-export default (getAllProjectionsInfo) => async (name) => {
-	assert(name, `${baseErr}Name not provided`);
+export default (getAllProjectionsInfo, getConfig) => async (
+  name,
+  includeConfig
+) => {
+  assert(name, `${baseErr}Name not provided`);
 
-	const projectionsInfo = await getAllProjectionsInfo();
-	const projectionInfo = projectionsInfo.projections.find(projection => projection.name === name);
-	debug('', 'Projection Info: %j', projectionInfo);
-	return projectionInfo;
+  const projectionsInfo = await getAllProjectionsInfo();
+  const projectionInfo = projectionsInfo.projections.find(
+    (projection) => projection.name === name
+  );
+  debug("", "Projection Info: %j", projectionInfo);
+
+  if (includeConfig === true) {
+    const config = await getConfig(name);
+    debug("", "Config: %j", config);
+    return { ...projectionInfo, config };
+  }
+
+  return projectionInfo;
 };

--- a/tests/http.projections.js
+++ b/tests/http.projections.js
@@ -76,6 +76,22 @@ describe('Projections', () => {
 			const removeResponse = await client.projections.remove(assertionProjection);
 			assert.equal(removeResponse.name, assertionProjection);
 		});
+
+		it('Should get config for continuous projection', async function () {
+			this.timeout(10 * 1000);
+			const client = new EventStore.HTTPClient(httpConfig);
+
+			const projectionConfig = await client.projections.config(assertionProjection);
+			await sleep(1000);
+
+			assert.equal(projectionConfig.emitEnabled, false);
+			assert.equal(projectionConfig.trackEmittedStreams, false);
+			assert.equal(projectionConfig.msgTypeId, 268);
+			assert.equal(projectionConfig.checkpointHandledThreshold, 4000);
+			assert.equal(projectionConfig.checkpointUnhandledBytesThreshold, 10000000);
+			assert.equal(projectionConfig.pendingEventsThreshold, 5000);
+			assert.equal(projectionConfig.maxWriteBatchLength, 500);
+		});
 	});
 
 	describe('Custom Settings', () => {

--- a/tests/http.projections.js
+++ b/tests/http.projections.js
@@ -83,9 +83,12 @@ describe('Projections', () => {
 			this.timeout(10 * 1000);
 			const client = new EventStore.HTTPClient(httpConfig);
 
-			const response = await client.projections.assert(assertionProjection, assertionProjectionContent, 'onetime', true, true, true);
+			const response = await client.projections.assert(assertionProjection, assertionProjectionContent, 'onetime', true, true, true, true);
 			await sleep(2000);
 			assert.equal(response.name, assertionProjection);
+			const responseWithTrackEmittedStreamsEnabled = await client.projections.getInfo(assertionProjection, true);
+			assert.equal(responseWithTrackEmittedStreamsEnabled.config.trackEmittedStreams, true);
+			assert.equal(responseWithTrackEmittedStreamsEnabled.config.emitEnabled, true);
 		});
 
 		it('Should remove one-time projection', async function () {

--- a/tests/http.projections.js
+++ b/tests/http.projections.js
@@ -1,11 +1,12 @@
 import './_globalHooks';
 
+import assert from 'assert';
+import fs from 'fs';
+
+import EventStore from '../lib';
 import generateEventId from '../lib/utilities/generateEventId';
 import httpConfig from './support/httpConfig';
 import sleep from './utilities/sleep';
-import EventStore from '../lib';
-import assert from 'assert';
-import fs from 'fs';
 
 describe('Projections', () => {
 	describe('Default Settings', () => {
@@ -20,6 +21,10 @@ describe('Projections', () => {
 
 			const response = await client.projections.assert(assertionProjection, assertionProjectionContent);
 			assert.equal(response.name, assertionProjection);
+
+			const responseWithTrackEmittedStreamsEnabled = await client.projections.getInfo(assertionProjection, true);
+			assert.equal(responseWithTrackEmittedStreamsEnabled.config.emitEnabled, false);
+			assert.equal(responseWithTrackEmittedStreamsEnabled.config.trackEmittedStreams, false);
 		});
 
 		it('Should update existing projection', async function () {


### PR DESCRIPTION
# Issues

## TrackEmittedStreams

The current version of `geteventstore-promise` does not allow to set `trackEmittedStreams` parameter to `true`. This feature is usefull when we want to delete a projection and it's emitted streams.

## GetInfo

To be able to test and validate the previous feature I've added the projection getInfo feature to add configuration informations.