### PR TITLE
fix(projections): fix trackEmittedStreams options

### DIFF
--- a/lib/httpClient/projections/assert.js
+++ b/lib/httpClient/projections/assert.js
@@ -1,6 +1,6 @@
-import debugModule from 'debug';
 import assert from 'assert';
 import axios from 'axios';
+import debugModule from 'debug';
 
 const debug = debugModule('geteventstore:assertProjection');
 const baseErr = 'Assert Projection - ';
@@ -58,7 +58,7 @@ export default (config, getAllProjectionsInfo) => async (name, projectionContent
 	enabled = enabled || true;
 	checkpointsEnabled = mode === 'continuous' ? true : checkpointsEnabled || false;
 	emitEnabled = emitEnabled || false;
-	trackEmittedStreams = emitEnabled || false;
+	trackEmittedStreams = trackEmittedStreams || false;
 
 	const projectionsInfo = await getAllProjectionsInfo();
 	const projectionExists = await doesProjectionExist(projectionsInfo, name);

--- a/tests/http.projections.js
+++ b/tests/http.projections.js
@@ -121,6 +121,23 @@ describe('Projections', () => {
 			const removeResponse = await client.projections.remove(assertionProjection);
 			assert.equal(removeResponse.name, assertionProjection);
 		});
+
+		it('Should create one-time projection with emits enabled but trackEmittedStreams disabled then remove it', async function () {
+			this.timeout(10 * 1000);
+			const client = new EventStore.HTTPClient(httpConfig);
+
+			const response = await client.projections.assert(assertionProjection, assertionProjectionContent, 'onetime', true, true, true);
+			await sleep(2000);
+			assert.equal(response.name, assertionProjection);
+			const responseWithTrackEmittedStreamsEnabled = await client.projections.getInfo(assertionProjection, true);
+			assert.equal(responseWithTrackEmittedStreamsEnabled.config.trackEmittedStreams, false);
+			assert.equal(responseWithTrackEmittedStreamsEnabled.config.emitEnabled, true);
+
+			const stopResponse = await client.projections.stop(assertionProjection);
+			assert.equal(stopResponse.name, assertionProjection);
+			const removeResponse = await client.projections.remove(assertionProjection);
+			assert.equal(removeResponse.name, assertionProjection);
+		});
 	});
 
 	describe('Global Projections Operations', () => {


### PR DESCRIPTION
I saw that I made a mistake in `trackEmittedStreams` assignment  in projections assertion. The parameter was taking the value from `emitEnabled`. Nothing was break but every `emitEnabled` projections was also configured to track emitted streams.

I've added a test to confirm the issue before fixing it.

Sorry for that mistake!